### PR TITLE
Security: Bump bytes to 1.11.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ bincode = "1"
 bitvec = "1"
 bls = { path = "crypto/bls" }
 byteorder = "1"
-bytes = "1"
+bytes = "1.11.1"
 # Turn off c-kzg's default features which include `blst/portable`. We can turn on blst's portable
 # feature ourselves when desired.
 c-kzg = { version = "2.1", default-features = false }


### PR DESCRIPTION
Fixes RUSTSEC-2026-0007 - vulnerability in bytes crate