### PR TITLE
Tests: Update to consensus-specs v1.7.0-alpha.2

### DIFF
--- a/testing/ef_tests/Makefile
+++ b/testing/ef_tests/Makefile
@@ -1,6 +1,6 @@
 # To download/extract nightly tests, run:
 # CONSENSUS_SPECS_TEST_VERSION=nightly make
-CONSENSUS_SPECS_TEST_VERSION ?= v1.6.0-alpha.6
+CONSENSUS_SPECS_TEST_VERSION ?= v1.7.0-alpha.2
 REPO_NAME := consensus-spec-tests
 OUTPUT_DIR := ./$(REPO_NAME)
 

--- a/testing/ef_tests/download_test_vectors.sh
+++ b/testing/ef_tests/download_test_vectors.sh
@@ -57,7 +57,7 @@ else
 		if [[ ! -e "${test}.tar.gz" ]]; then
 			echo "Downloading: ${version}/${test}.tar.gz"
 			curl --progress-bar --location --remote-name --show-error --retry 3 --retry-all-errors --fail \
-				"https://github.com/ethereum/consensus-spec-tests/releases/download/${version}/${test}.tar.gz" \
+				"https://github.com/ethereum/consensus-specs/releases/download/${version}/${test}.tar.gz" \
 				|| {
 					echo "Curl failed. Aborting"
 					rm -f "${test}.tar.gz"


### PR DESCRIPTION
Updates test infrastructure to gloas v1.7.0-alpha.2. Downloads 2,168 gloas spec test files.