### PR TITLE
convert DataColumnSidecar to superstruct with Fulu/Gloas variants

### DIFF
--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -187,7 +187,7 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
         self.availability_cache
             .peek_pending_components(block_root, |components| {
                 components.is_some_and(|components| {
-                    let cached_column_opt = components.get_cached_data_column(data_column.index);
+                    let cached_column_opt = components.get_cached_data_column(*data_column.index());
                     cached_column_opt.is_some_and(|cached| *cached == *data_column)
                 })
             })

--- a/beacon_node/beacon_chain/src/fetch_blobs/mod.rs
+++ b/beacon_node/beacon_chain/src/fetch_blobs/mod.rs
@@ -370,7 +370,7 @@ async fn compute_custody_columns_to_import<T: BeaconChainTypes>(
                     .map(|data_columns| {
                         data_columns
                             .into_iter()
-                            .filter(|col| custody_columns_indices.contains(&col.index))
+                            .filter(|col| custody_columns_indices.contains(col.index()))
                             .map(|col| {
                                 KzgVerifiedCustodyDataColumn::from_asserted_custody(
                                     KzgVerifiedDataColumn::from_execution_verified(col),

--- a/beacon_node/beacon_chain/src/historical_data_columns.rs
+++ b/beacon_node/beacon_chain/src/historical_data_columns.rs
@@ -86,7 +86,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 {
                     if self
                         .store
-                        .get_data_column(&block_root, &data_column.index)?
+                        .get_data_column(&block_root, data_column.index())?
                         .is_some()
                     {
                         continue;

--- a/beacon_node/beacon_chain/src/historical_data_columns.rs
+++ b/beacon_node/beacon_chain/src/historical_data_columns.rs
@@ -61,12 +61,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         let unique_column_indices = historical_data_column_sidecar_list
             .iter()
-            .map(|item| item.index)
+            .map(|item| *item.index())
             .collect::<HashSet<_>>();
 
         let mut slot_and_column_index_to_data_columns = historical_data_column_sidecar_list
             .iter()
-            .map(|data_column| ((data_column.slot(), data_column.index), data_column))
+            .map(|data_column| ((data_column.slot(), *data_column.index()), data_column))
             .collect::<HashMap<_, _>>();
 
         let forward_blocks_iter = self

--- a/beacon_node/beacon_chain/src/kzg_utils.rs
+++ b/beacon_node/beacon_chain/src/kzg_utils.rs
@@ -9,9 +9,9 @@ use tracing::instrument;
 use types::beacon_block_body::KzgCommitments;
 use types::data_column_sidecar::{Cell, DataColumn, DataColumnSidecarError};
 use types::{
-    Blob, BlobSidecar, BlobSidecarList, ChainSpec, DataColumnSidecar, DataColumnSidecarList,
-    EthSpec, Hash256, KzgCommitment, KzgProof, SignedBeaconBlock, SignedBeaconBlockHeader,
-    SignedBlindedBeaconBlock,
+    Blob, BlobSidecar, BlobSidecarList, ChainSpec, DataColumnSidecar, DataColumnSidecarFulu,
+    DataColumnSidecarList, EthSpec, Hash256, KzgCommitment, KzgProof, SignedBeaconBlock,
+    SignedBeaconBlockHeader, SignedBlindedBeaconBlock,
 };
 
 /// Converts a blob ssz List object to an array to be used with the kzg
@@ -59,22 +59,33 @@ where
     let mut commitments = Vec::new();
 
     for data_column in data_column_iter {
-        let col_index = data_column.index;
+        let col_index = *data_column.index();
 
-        if data_column.column.is_empty() {
+        if data_column.column().is_empty() {
             return Err((Some(col_index), KzgError::KzgVerificationFailed));
         }
 
-        for cell in &data_column.column {
+        for cell in data_column.column() {
             cells.push(ssz_cell_to_crypto_cell::<E>(cell).map_err(|e| (Some(col_index), e))?);
             column_indices.push(col_index);
         }
 
-        for &proof in &data_column.kzg_proofs {
+        for &proof in data_column.kzg_proofs() {
             proofs.push(Bytes48::from(proof));
         }
 
-        for &commitment in &data_column.kzg_commitments {
+        let kzg_commitments = match data_column.as_ref() {
+            DataColumnSidecar::Fulu(col) => &col.kzg_commitments,
+            DataColumnSidecar::Gloas(_) => {
+                return Err((
+                    Some(col_index),
+                    KzgError::InconsistentArrayLength(
+                        "Gloas data columns do not carry kzg_commitments".to_string(),
+                    ),
+                ));
+            }
+        };
+        for &commitment in kzg_commitments {
             commitments.push(Bytes48::from(commitment));
         }
 
@@ -281,14 +292,14 @@ pub(crate) fn build_data_column_sidecars<E: EthSpec>(
         .zip(column_kzg_proofs)
         .enumerate()
         .map(|(index, (col, proofs))| {
-            Arc::new(DataColumnSidecar {
+            Arc::new(DataColumnSidecar::Fulu(DataColumnSidecarFulu {
                 index: index as u64,
                 column: DataColumn::<E>::from(col),
                 kzg_commitments: kzg_commitments.clone(),
                 kzg_proofs: VariableList::from(proofs),
                 signed_block_header: signed_block_header.clone(),
                 kzg_commitments_inclusion_proof: kzg_commitments_inclusion_proof.clone(),
-            })
+            }))
         })
         .collect();
 
@@ -313,10 +324,14 @@ pub fn reconstruct_blobs<E: EthSpec>(
         .first()
         .ok_or("data_columns should have at least one element".to_string())?;
 
+    let first_data_column_fulu = first_data_column
+        .as_fulu()
+        .map_err(|_| "reconstruct_blobs requires Fulu data columns".to_string())?;
+
     let blob_indices: Vec<usize> = match blob_indices_opt {
         Some(indices) => indices.into_iter().map(|i| i as usize).collect(),
         None => {
-            let num_of_blobs = first_data_column.kzg_commitments.len();
+            let num_of_blobs = first_data_column_fulu.kzg_commitments.len();
             (0..num_of_blobs).collect()
         }
     };
@@ -328,7 +343,7 @@ pub fn reconstruct_blobs<E: EthSpec>(
             let mut cell_ids: Vec<u64> = vec![];
             for data_column in data_columns {
                 let cell = data_column
-                    .column
+                    .column()
                     .get(row_index)
                     .ok_or(format!("Missing data column at row index {row_index}"))
                     .and_then(|cell| {
@@ -336,7 +351,7 @@ pub fn reconstruct_blobs<E: EthSpec>(
                     })?;
 
                 cells.push(cell);
-                cell_ids.push(data_column.index);
+                cell_ids.push(*data_column.index());
             }
 
             let num_cells_original_blob = E::number_of_columns() / 2;
@@ -367,8 +382,8 @@ pub fn reconstruct_blobs<E: EthSpec>(
                 row_index,
                 blob,
                 signed_block,
-                first_data_column.signed_block_header.clone(),
-                &first_data_column.kzg_commitments_inclusion_proof,
+                first_data_column_fulu.signed_block_header.clone(),
+                &first_data_column_fulu.kzg_commitments_inclusion_proof,
                 kzg_proof,
             )
             .map(Arc::new)
@@ -388,7 +403,7 @@ pub fn reconstruct_data_columns<E: EthSpec>(
     spec: &ChainSpec,
 ) -> Result<DataColumnSidecarList<E>, KzgError> {
     // Sort data columns by index to ensure ascending order for KZG operations
-    data_columns.sort_unstable_by_key(|dc| dc.index);
+    data_columns.sort_unstable_by_key(|dc| *dc.index());
 
     let first_data_column = data_columns
         .first()
@@ -396,7 +411,14 @@ pub fn reconstruct_data_columns<E: EthSpec>(
             "data_columns should have at least one element".to_string(),
         ))?;
 
-    let num_of_blobs = first_data_column.kzg_commitments.len();
+    let first_data_column_fulu =
+        first_data_column
+            .as_fulu()
+            .map_err(|_| KzgError::InconsistentArrayLength(
+                "reconstruct_data_columns requires Fulu data columns".to_string(),
+            ))?;
+
+    let num_of_blobs = first_data_column_fulu.kzg_commitments.len();
 
     let blob_cells_and_proofs_vec =
         (0..num_of_blobs)
@@ -405,14 +427,14 @@ pub fn reconstruct_data_columns<E: EthSpec>(
                 let mut cells: Vec<KzgCellRef> = vec![];
                 let mut cell_ids: Vec<u64> = vec![];
                 for data_column in &data_columns {
-                    let cell = data_column.column.get(row_index).ok_or(
+                    let cell = data_column.column().get(row_index).ok_or(
                         KzgError::InconsistentArrayLength(format!(
                             "Missing data column at row index {row_index}"
                         )),
                     )?;
 
                     cells.push(ssz_cell_to_crypto_cell::<E>(cell)?);
-                    cell_ids.push(data_column.index);
+                    cell_ids.push(*data_column.index());
                 }
                 kzg.recover_cells_and_compute_kzg_proofs(&cell_ids, &cells)
             })
@@ -420,9 +442,9 @@ pub fn reconstruct_data_columns<E: EthSpec>(
 
     // Clone sidecar elements from existing data column, no need to re-compute
     build_data_column_sidecars(
-        first_data_column.kzg_commitments.clone(),
-        first_data_column.kzg_commitments_inclusion_proof.clone(),
-        first_data_column.signed_block_header.clone(),
+        first_data_column_fulu.kzg_commitments.clone(),
+        first_data_column_fulu.kzg_commitments_inclusion_proof.clone(),
+        first_data_column_fulu.signed_block_header.clone(),
         blob_cells_and_proofs_vec,
         spec,
     )
@@ -512,18 +534,19 @@ mod test {
 
         assert_eq!(column_sidecars.len(), E::number_of_columns());
         for (idx, col_sidecar) in column_sidecars.iter().enumerate() {
-            assert_eq!(col_sidecar.index, idx as u64);
+            let col_fulu = col_sidecar.as_fulu().expect("expected Fulu variant");
+            assert_eq!(*col_sidecar.index(), idx as u64);
 
-            assert_eq!(col_sidecar.kzg_commitments.len(), num_of_blobs);
-            assert_eq!(col_sidecar.column.len(), num_of_blobs);
-            assert_eq!(col_sidecar.kzg_proofs.len(), num_of_blobs);
+            assert_eq!(col_fulu.kzg_commitments.len(), num_of_blobs);
+            assert_eq!(col_sidecar.column().len(), num_of_blobs);
+            assert_eq!(col_sidecar.kzg_proofs().len(), num_of_blobs);
 
-            assert_eq!(col_sidecar.kzg_commitments, block_kzg_commitments);
+            assert_eq!(col_fulu.kzg_commitments, block_kzg_commitments);
             assert_eq!(
-                col_sidecar.kzg_commitments_inclusion_proof,
+                col_fulu.kzg_commitments_inclusion_proof,
                 block_kzg_commitments_inclusion_proof
             );
-            assert!(col_sidecar.verify_inclusion_proof());
+            assert!(col_fulu.verify_inclusion_proof());
         }
     }
 

--- a/beacon_node/beacon_chain/src/observed_data_sidecars.rs
+++ b/beacon_node/beacon_chain/src/observed_data_sidecars.rs
@@ -47,15 +47,18 @@ impl<E: EthSpec> ObservableDataSidecar for BlobSidecar<E> {
 
 impl<E: EthSpec> ObservableDataSidecar for DataColumnSidecar<E> {
     fn slot(&self) -> Slot {
-        self.slot()
+        DataColumnSidecar::slot(self)
     }
 
     fn block_proposer_index(&self) -> u64 {
-        self.block_proposer_index()
+        match self {
+            DataColumnSidecar::Fulu(col) => col.block_proposer_index(),
+            DataColumnSidecar::Gloas(_) => 0,
+        }
     }
 
     fn index(&self) -> u64 {
-        self.index
+        *DataColumnSidecar::index(self)
     }
 
     fn max_num_of_items(_spec: &ChainSpec, _slot: Slot) -> usize {

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -2448,7 +2448,7 @@ where
                 // currently have any knowledge of the columns being custodied.
                 let columns = generate_data_column_sidecars_from_block(&block, &self.spec)
                     .into_iter()
-                    .filter(|d| sampling_columns.contains(&d.index))
+                    .filter(|d| sampling_columns.contains(d.index()))
                     .map(CustodyDataColumn::from_asserted_custody)
                     .collect::<Vec<_>>();
                 RpcBlock::new_with_custody_columns(Some(block_root), block, columns)?
@@ -3188,10 +3188,10 @@ where
 
             let verified_columns = generate_data_column_sidecars_from_block(block, &self.spec)
                 .into_iter()
-                .filter(|c| custody_columns.contains(&c.index))
+                .filter(|c| custody_columns.contains(c.index()))
                 .map(|sidecar| {
                     let subnet_id =
-                        DataColumnSubnetId::from_column_index(sidecar.index, &self.spec);
+                        DataColumnSubnetId::from_column_index(*sidecar.index(), &self.spec);
                     self.chain
                         .verify_data_column_sidecar_for_gossip(sidecar, subnet_id)
                 })
@@ -3383,9 +3383,8 @@ pub fn generate_data_column_sidecars_from_block<E: EthSpec>(
     let (cells, proofs) = template_data_columns
         .into_iter()
         .map(|sidecar| {
-            let DataColumnSidecar {
-                column, kzg_proofs, ..
-            } = sidecar;
+            let column = sidecar.column().clone();
+            let kzg_proofs = sidecar.kzg_proofs().clone();
             // There's only one cell per column for a single blob
             let cell_bytes: Vec<u8> = column.into_iter().next().unwrap().into();
             let kzg_cell = cell_bytes.try_into().unwrap();

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -3374,17 +3374,19 @@ pub fn generate_data_column_sidecars_from_block<E: EthSpec>(
     let signed_block_header = block.signed_block_header();
 
     // load the precomputed column sidecar to avoid computing them for every block in the tests.
-    let template_data_columns = RuntimeVariableList::<DataColumnSidecar<E>>::from_ssz_bytes(
-        TEST_DATA_COLUMN_SIDECARS_SSZ,
-        E::number_of_columns(),
-    )
-    .unwrap();
+    // The pre-computed SSZ data is in Fulu format.
+    let template_data_columns =
+        RuntimeVariableList::<DataColumnSidecarFulu<E>>::from_ssz_bytes(
+            TEST_DATA_COLUMN_SIDECARS_SSZ,
+            E::number_of_columns(),
+        )
+        .unwrap();
 
     let (cells, proofs) = template_data_columns
         .into_iter()
         .map(|sidecar| {
-            let column = sidecar.column().clone();
-            let kzg_proofs = sidecar.kzg_proofs().clone();
+            let column = sidecar.column.clone();
+            let kzg_proofs = sidecar.kzg_proofs.clone();
             // There's only one cell per column for a single blob
             let cell_bytes: Vec<u8> = column.into_iter().next().unwrap().into();
             let kzg_cell = cell_bytes.try_into().unwrap();

--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -515,14 +515,14 @@ fn publish_column_sidecars<T: BeaconChainTypes>(
         data_column_sidecars.shuffle(&mut **chain.rng.lock());
         let dropped_indices = data_column_sidecars
             .drain(columns_to_keep..)
-            .map(|d| d.index)
+            .map(|d| *d.index())
             .collect::<Vec<_>>();
         debug!(indices = ?dropped_indices, "Dropping data columns from publishing");
     }
     let pubsub_messages = data_column_sidecars
         .into_iter()
         .map(|data_col| {
-            let subnet = DataColumnSubnetId::from_column_index(data_col.index, &chain.spec);
+            let subnet = DataColumnSubnetId::from_column_index(*data_col.index(), &chain.spec);
             PubsubMessage::DataColumnSidecar(Box::new((subnet, data_col)))
         })
         .collect::<Vec<_>>();

--- a/beacon_node/lighthouse_network/src/rpc/codec.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec.rs
@@ -693,7 +693,7 @@ fn handle_rpc_response<E: EthSpec>(
             Some(fork_name) => {
                 if fork_name.fulu_enabled() {
                     Ok(Some(RpcSuccessResponse::DataColumnsByRoot(Arc::new(
-                        DataColumnSidecar::from_ssz_bytes(decoded_buffer)?,
+                        DataColumnSidecar::from_ssz_bytes_for_fork(decoded_buffer, fork_name)?,
                     ))))
                 } else {
                     Err(RPCError::ErrorResponse(
@@ -714,7 +714,7 @@ fn handle_rpc_response<E: EthSpec>(
             Some(fork_name) => {
                 if fork_name.fulu_enabled() {
                     Ok(Some(RpcSuccessResponse::DataColumnsByRange(Arc::new(
-                        DataColumnSidecar::from_ssz_bytes(decoded_buffer)?,
+                        DataColumnSidecar::from_ssz_bytes_for_fork(decoded_buffer, fork_name)?,
                     ))))
                 } else {
                     Err(RPCError::ErrorResponse(
@@ -910,9 +910,9 @@ mod tests {
     use crate::types::{EnrAttestationBitfield, EnrSyncCommitteeBitfield};
     use types::{
         BeaconBlock, BeaconBlockAltair, BeaconBlockBase, BeaconBlockBellatrix, BeaconBlockHeader,
-        DataColumnsByRootIdentifier, EmptyBlock, Epoch, FixedBytesExtended, FullPayload,
-        KzgCommitment, KzgProof, Signature, SignedBeaconBlockHeader, Slot,
-        blob_sidecar::BlobIdentifier, data_column_sidecar::Cell,
+        DataColumnSidecarFulu, DataColumnsByRootIdentifier, EmptyBlock, Epoch,
+        FixedBytesExtended, FullPayload, KzgCommitment, KzgProof, Signature,
+        SignedBeaconBlockHeader, Slot, blob_sidecar::BlobIdentifier, data_column_sidecar::Cell,
     };
 
     type Spec = types::MainnetEthSpec;
@@ -975,7 +975,7 @@ mod tests {
     fn empty_data_column_sidecar(spec: &ChainSpec) -> Arc<DataColumnSidecar<Spec>> {
         // The context bytes are now derived from the block epoch, so we need to have the slot set
         // here.
-        let data_column_sidecar = DataColumnSidecar {
+        let data_column_sidecar = DataColumnSidecar::Fulu(DataColumnSidecarFulu {
             index: 0,
             column: VariableList::new(vec![Cell::<Spec>::default()]).unwrap(),
             kzg_commitments: VariableList::new(vec![KzgCommitment::empty_for_testing()]).unwrap(),
@@ -991,7 +991,7 @@ mod tests {
                 signature: Signature::empty(),
             },
             kzg_commitments_inclusion_proof: Default::default(),
-        };
+        });
         Arc::new(data_column_sidecar)
     }
 

--- a/beacon_node/lighthouse_network/src/rpc/methods.rs
+++ b/beacon_node/lighthouse_network/src/rpc/methods.rs
@@ -760,9 +760,7 @@ impl<E: EthSpec> RpcSuccessResponse<E> {
             Self::BlobsByRange(r) | Self::BlobsByRoot(r) => {
                 Some(r.signed_block_header.message.slot)
             }
-            Self::DataColumnsByRange(r) | Self::DataColumnsByRoot(r) => {
-                Some(r.signed_block_header.message.slot)
-            }
+            Self::DataColumnsByRange(r) | Self::DataColumnsByRoot(r) => Some(r.slot()),
             Self::LightClientBootstrap(r) => Some(r.get_slot()),
             Self::LightClientFinalityUpdate(r) => Some(r.get_attested_header_slot()),
             Self::LightClientOptimisticUpdate(r) => Some(r.get_slot()),

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -16,7 +16,7 @@ use tokio_util::{
     compat::{Compat, FuturesAsyncReadCompatExt},
 };
 use types::{
-    BeaconBlock, BeaconBlockAltair, BeaconBlockBase, BlobSidecar, ChainSpec, DataColumnSidecar,
+    BeaconBlock, BeaconBlockAltair, BeaconBlockBase, BlobSidecar, ChainSpec, DataColumnSidecarFulu,
     EmptyBlock, Epoch, EthSpec, EthSpecId, ForkContext, ForkName, LightClientBootstrap,
     LightClientBootstrapAltair, LightClientFinalityUpdate, LightClientFinalityUpdateAltair,
     LightClientOptimisticUpdate, LightClientOptimisticUpdateAltair, LightClientUpdate,
@@ -638,8 +638,8 @@ pub fn rpc_data_column_limits<E: EthSpec>(
     spec: &ChainSpec,
 ) -> RpcLimits {
     RpcLimits::new(
-        DataColumnSidecar::<E>::min_size(),
-        DataColumnSidecar::<E>::max_size(spec.max_blobs_per_block(current_digest_epoch) as usize),
+        DataColumnSidecarFulu::<E>::min_size(),
+        DataColumnSidecarFulu::<E>::max_size(spec.max_blobs_per_block(current_digest_epoch) as usize),
     )
 }
 

--- a/beacon_node/lighthouse_network/src/types/pubsub.rs
+++ b/beacon_node/lighthouse_network/src/types/pubsub.rs
@@ -276,7 +276,7 @@ impl<E: EthSpec> PubsubMessage<E> {
                         match fork_context.get_fork_from_context_bytes(gossip_topic.fork_digest) {
                             Some(fork) if fork.fulu_enabled() => {
                                 let col_sidecar = Arc::new(
-                                    DataColumnSidecar::from_ssz_bytes(data)
+                                    DataColumnSidecar::from_ssz_bytes_for_fork(data, *fork)
                                         .map_err(|e| format!("{:?}", e))?,
                                 );
                                 Ok(PubsubMessage::DataColumnSidecar(Box::new((
@@ -436,7 +436,7 @@ impl<E: EthSpec> std::fmt::Display for PubsubMessage<E> {
                 f,
                 "DataColumnSidecar: slot: {}, column index: {}",
                 data.1.slot(),
-                data.1.index,
+                data.1.index(),
             ),
             PubsubMessage::AggregateAndProofAttestation(att) => write!(
                 f,

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -609,7 +609,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         parent = None,
         level = "debug",
         skip_all,
-        fields(slot = %column_sidecar.slot(), block_root = ?column_sidecar.block_root(), index = column_sidecar.index),
+        fields(slot = %column_sidecar.slot(), block_root = ?column_sidecar.block_root(), index = *column_sidecar.index()),
     )]
     pub async fn process_gossip_data_column_sidecar(
         self: &Arc<Self>,
@@ -621,7 +621,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     ) {
         let slot = column_sidecar.slot();
         let block_root = column_sidecar.block_root();
-        let index = column_sidecar.index;
+        let index = *column_sidecar.index();
         let delay = get_slot_delay_ms(seen_duration, slot, &self.chain.slot_clock);
         // Log metrics to track delay from other nodes on the network.
         metrics::observe_duration(

--- a/beacon_node/network/src/network_beacon_processor/mod.rs
+++ b/beacon_node/network/src/network_beacon_processor/mod.rs
@@ -977,7 +977,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                             .into_iter()
                             .map(|d| {
                                 let subnet =
-                                    DataColumnSubnetId::from_column_index(d.index, &chain.spec);
+                                    DataColumnSubnetId::from_column_index(*d.index(), &chain.spec);
                                 PubsubMessage::DataColumnSidecar(Box::new((subnet, d)))
                             })
                             .collect(),

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -374,7 +374,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             metrics::observe_duration(&metrics::BEACON_BLOB_RPC_SLOT_START_DELAY_TIME, delay);
         }
 
-        let mut indices = custody_columns.iter().map(|d| d.index).collect::<Vec<_>>();
+        let mut indices = custody_columns.iter().map(|d| *d.index()).collect::<Vec<_>>();
         indices.sort_unstable();
         debug!(
             ?indices,

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -345,7 +345,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
 
         for column in data_columns {
             let block_root = column.block_root();
-            let index = column.index;
+            let index = *column.index();
             if data_columns_by_block
                 .entry(block_root)
                 .or_default()
@@ -630,7 +630,7 @@ mod tests {
                 *req,
                 blocks
                     .iter()
-                    .flat_map(|b| b.1.iter().filter(|d| d.index == column_index).cloned())
+                    .flat_map(|b| b.1.iter().filter(|d| *d.index() == column_index).cloned())
                     .collect(),
             )
             .unwrap();
@@ -713,7 +713,7 @@ mod tests {
                     .iter()
                     .flat_map(|b| {
                         b.1.iter()
-                            .filter(|d| column_indices.contains(&d.index))
+                            .filter(|d| column_indices.contains(d.index()))
                             .cloned()
                     })
                     .collect::<Vec<_>>(),
@@ -785,7 +785,7 @@ mod tests {
                 *req,
                 blocks
                     .iter()
-                    .flat_map(|b| b.1.iter().filter(|d| d.index == column_index).cloned())
+                    .flat_map(|b| b.1.iter().filter(|d| *d.index() == column_index).cloned())
                     .collect(),
             )
             .unwrap();
@@ -870,7 +870,7 @@ mod tests {
             *req1,
             blocks
                 .iter()
-                .flat_map(|b| b.1.iter().filter(|d| d.index == 1).cloned())
+                .flat_map(|b| b.1.iter().filter(|d| *d.index() == 1).cloned())
                 .collect(),
         )
         .unwrap();
@@ -897,7 +897,7 @@ mod tests {
             new_columns_req_id,
             blocks
                 .iter()
-                .flat_map(|b| b.1.iter().filter(|d| d.index == 2).cloned())
+                .flat_map(|b| b.1.iter().filter(|d| *d.index() == 2).cloned())
                 .collect(),
         )
         .unwrap();
@@ -963,7 +963,7 @@ mod tests {
             *req1,
             blocks
                 .iter()
-                .flat_map(|b| b.1.iter().filter(|d| d.index == 1).cloned())
+                .flat_map(|b| b.1.iter().filter(|d| *d.index() == 1).cloned())
                 .collect(),
         )
         .unwrap();

--- a/beacon_node/network/src/sync/network_context/custody.rs
+++ b/beacon_node/network/src/sync/network_context/custody.rs
@@ -128,7 +128,7 @@ impl<T: BeaconChainTypes> ActiveCustodyRequest<T> {
                 // requested index. The worse case is 128 loops over a 128 item vec + mutation to
                 // drop the consumed columns.
                 let mut data_columns = HashMap::<ColumnIndex, _>::from_iter(
-                    data_columns.into_iter().map(|d| (d.index, d)),
+                    data_columns.into_iter().map(|d| (*d.index(), d)),
                 );
                 // Accumulate columns that the peer does not have to issue a single log per request
                 let mut missing_column_indexes = vec![];
@@ -210,7 +210,7 @@ impl<T: BeaconChainTypes> ActiveCustodyRequest<T> {
                     peers
                         .entry(peer)
                         .or_default()
-                        .push(data_column.index as usize);
+                        .push(*data_column.index() as usize);
                     seen_timestamps.push(seen_timestamp);
                     Ok(data_column)
                 })

--- a/beacon_node/network/src/sync/network_context/requests/data_columns_by_range.rs
+++ b/beacon_node/network/src/sync/network_context/requests/data_columns_by_range.rs
@@ -28,18 +28,18 @@ impl<E: EthSpec> ActiveRequestItems for DataColumnsByRangeRequestItems<E> {
         {
             return Err(LookupVerifyError::UnrequestedSlot(data_column.slot()));
         }
-        if !self.request.columns.contains(&data_column.index) {
-            return Err(LookupVerifyError::UnrequestedIndex(data_column.index));
+        if !self.request.columns.contains(data_column.index()) {
+            return Err(LookupVerifyError::UnrequestedIndex(*data_column.index()));
         }
         if !data_column.verify_inclusion_proof() {
             return Err(LookupVerifyError::InvalidInclusionProof);
         }
         if self.items.iter().any(|existing| {
-            existing.slot() == data_column.slot() && existing.index == data_column.index
+            existing.slot() == data_column.slot() && existing.index() == data_column.index()
         }) {
             return Err(LookupVerifyError::DuplicatedData(
                 data_column.slot(),
-                data_column.index,
+                *data_column.index(),
             ));
         }
 

--- a/beacon_node/network/src/sync/network_context/requests/data_columns_by_root.rs
+++ b/beacon_node/network/src/sync/network_context/requests/data_columns_by_root.rs
@@ -59,13 +59,13 @@ impl<E: EthSpec> ActiveRequestItems for DataColumnsByRootRequestItems<E> {
         if !data_column.verify_inclusion_proof() {
             return Err(LookupVerifyError::InvalidInclusionProof);
         }
-        if !self.request.indices.contains(&data_column.index) {
-            return Err(LookupVerifyError::UnrequestedIndex(data_column.index));
+        if !self.request.indices.contains(data_column.index()) {
+            return Err(LookupVerifyError::UnrequestedIndex(*data_column.index()));
         }
-        if self.items.iter().any(|d| d.index == data_column.index) {
+        if self.items.iter().any(|d| d.index() == data_column.index()) {
             return Err(LookupVerifyError::DuplicatedData(
                 data_column.slot(),
-                data_column.index,
+                *data_column.index(),
             ));
         }
 

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -112,7 +112,7 @@ impl<E: EthSpec> BlockCache<E> {
     pub fn put_data_column(&mut self, block_root: Hash256, data_column: Arc<DataColumnSidecar<E>>) {
         self.data_column_cache
             .get_or_insert_mut(block_root, Default::default)
-            .insert(data_column.index, data_column);
+            .insert(*data_column.index(), data_column);
     }
     pub fn put_data_column_custody_info(
         &mut self,
@@ -967,7 +967,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     ) {
         ops.push(KeyValueStoreOp::PutKeyValue(
             DBColumn::BeaconDataColumn,
-            get_data_column_key(block_root, &data_column.index),
+            get_data_column_key(block_root, &data_column.index()),
             data_column.as_ssz_bytes(),
         ));
     }
@@ -1000,7 +1000,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         for data_column in data_columns {
             self.blobs_db.put_bytes(
                 DBColumn::BeaconDataColumn,
-                &get_data_column_key(block_root, &data_column.index),
+                &get_data_column_key(block_root, &data_column.index()),
                 &data_column.as_ssz_bytes(),
             )?;
             self.block_cache
@@ -1019,7 +1019,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         for data_column in data_columns {
             ops.push(KeyValueStoreOp::PutKeyValue(
                 DBColumn::BeaconDataColumn,
-                get_data_column_key(block_root, &data_column.index),
+                get_data_column_key(block_root, &data_column.index()),
                 data_column.as_ssz_bytes(),
             ));
         }
@@ -1464,7 +1464,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                 let reverse_op = match op {
                     StoreOp::PutBlobs(block_root, _) => StoreOp::DeleteBlobs(*block_root),
                     StoreOp::PutDataColumns(block_root, data_columns) => {
-                        let indices = data_columns.iter().map(|c| c.index).collect();
+                        let indices = data_columns.iter().map(|c| *c.index()).collect();
                         StoreOp::DeleteDataColumns(*block_root, indices)
                     }
                     StoreOp::DeleteBlobs(_) => match blobs_to_delete.pop() {
@@ -2594,7 +2594,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             &get_data_column_key(block_root, column_index),
         )? {
             Some(ref data_column_bytes) => {
-                let data_column = Arc::new(DataColumnSidecar::from_ssz_bytes(data_column_bytes)?);
+                let data_column = Arc::new(DataColumnSidecar::any_from_ssz_bytes(data_column_bytes)?);
                 self.block_cache.as_ref().inspect(|cache| {
                     cache
                         .lock()

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1036,14 +1036,17 @@ impl SseDataColumnSidecar {
     pub fn from_data_column_sidecar<E: EthSpec>(
         data_column_sidecar: &DataColumnSidecar<E>,
     ) -> SseDataColumnSidecar {
-        let kzg_commitments = data_column_sidecar.kzg_commitments.to_vec();
+        let kzg_commitments = match data_column_sidecar {
+            DataColumnSidecar::Fulu(col) => col.kzg_commitments.to_vec(),
+            DataColumnSidecar::Gloas(_) => vec![],
+        };
         let versioned_hashes = kzg_commitments
             .iter()
             .map(|c| c.calculate_versioned_hash())
             .collect();
         SseDataColumnSidecar {
             block_root: data_column_sidecar.block_root(),
-            index: data_column_sidecar.index,
+            index: *data_column_sidecar.index(),
             slot: data_column_sidecar.slot(),
             kzg_commitments,
             versioned_hashes,

--- a/consensus/types/src/data_column_sidecar.rs
+++ b/consensus/types/src/data_column_sidecar.rs
@@ -12,11 +12,12 @@ use kzg::{KzgCommitment, KzgProof};
 use merkle_proof::verify_merkle_proof;
 use safe_arith::ArithError;
 use serde::{Deserialize, Serialize};
-use ssz::Encode;
+use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use ssz_types::Error as SszError;
 use ssz_types::{FixedVector, VariableList};
 use std::sync::Arc;
+use superstruct::superstruct;
 use test_random_derive::TestRandom;
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
@@ -35,37 +36,138 @@ pub struct DataColumnsByRootIdentifier<E: EthSpec> {
 
 pub type DataColumnSidecarList<E> = Vec<Arc<DataColumnSidecar<E>>>;
 
+#[superstruct(
+    variants(Fulu, Gloas),
+    variant_attributes(
+        derive(
+            Debug,
+            Clone,
+            Serialize,
+            Deserialize,
+            Decode,
+            Encode,
+            TestRandom,
+            Derivative,
+            TreeHash,
+        ),
+        context_deserialize(ForkName),
+        derivative(PartialEq, Hash(bound = "E: EthSpec")),
+        serde(bound = "E: EthSpec", deny_unknown_fields),
+        cfg_attr(
+            feature = "arbitrary",
+            derive(arbitrary::Arbitrary),
+            arbitrary(bound = "E: EthSpec")
+        )
+    ),
+    ref_attributes(derive(TreeHash), tree_hash(enum_behaviour = "transparent")),
+    cast_error(ty = "DataColumnSidecarError", expr = "DataColumnSidecarError::IncorrectVariant"),
+    partial_getter_error(ty = "DataColumnSidecarError", expr = "DataColumnSidecarError::IncorrectVariant")
+)]
 #[cfg_attr(
     feature = "arbitrary",
     derive(arbitrary::Arbitrary),
     arbitrary(bound = "E: EthSpec")
 )]
-#[derive(
-    Debug, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom, Derivative,
-)]
-#[serde(bound = "E: EthSpec")]
-#[derivative(PartialEq, Eq, Hash(bound = "E: EthSpec"))]
-#[context_deserialize(ForkName)]
+#[derive(Debug, Clone, Serialize, TreeHash, Encode, Derivative, Deserialize)]
+#[derivative(PartialEq, Hash(bound = "E: EthSpec"))]
+#[serde(bound = "E: EthSpec", untagged, deny_unknown_fields)]
+#[tree_hash(enum_behaviour = "transparent")]
+#[ssz(enum_behaviour = "transparent")]
 pub struct DataColumnSidecar<E: EthSpec> {
     #[serde(with = "serde_utils::quoted_u64")]
     pub index: ColumnIndex,
     #[serde(with = "ssz_types::serde_utils::list_of_hex_fixed_vec")]
     pub column: DataColumn<E>,
-    /// All the KZG commitments and proofs associated with the block, used for verifying sample cells.
+    /// All the KZG commitments associated with the block, used for verifying sample cells.
+    #[superstruct(only(Fulu))]
     pub kzg_commitments: KzgCommitments<E>,
     pub kzg_proofs: VariableList<KzgProof, E::MaxBlobCommitmentsPerBlock>,
+    #[superstruct(only(Fulu))]
     pub signed_block_header: SignedBeaconBlockHeader,
     /// An inclusion proof, proving the inclusion of `blob_kzg_commitments` in `BeaconBlockBody`.
+    #[superstruct(only(Fulu))]
     pub kzg_commitments_inclusion_proof: FixedVector<Hash256, E::KzgCommitmentsInclusionProofDepth>,
+    #[superstruct(only(Gloas), partial_getter(rename = "slot_gloas"))]
+    pub slot: Slot,
+    #[superstruct(only(Gloas))]
+    pub beacon_block_root: Hash256,
 }
 
 impl<E: EthSpec> DataColumnSidecar<E> {
     pub fn slot(&self) -> Slot {
-        self.signed_block_header.message.slot
+        match self {
+            DataColumnSidecar::Fulu(column) => column.slot(),
+            DataColumnSidecar::Gloas(column) => column.slot,
+        }
     }
 
     pub fn epoch(&self) -> Epoch {
         self.slot().epoch(E::slots_per_epoch())
+    }
+
+    pub fn block_root(&self) -> Hash256 {
+        match self {
+            DataColumnSidecar::Fulu(column) => column.block_root(),
+            DataColumnSidecar::Gloas(column) => column.beacon_block_root,
+        }
+    }
+
+    pub fn block_parent_root(&self) -> Hash256 {
+        match self {
+            DataColumnSidecar::Fulu(column) => column.block_parent_root(),
+            DataColumnSidecar::Gloas(_) => Hash256::ZERO,
+        }
+    }
+
+    pub fn block_proposer_index(&self) -> u64 {
+        match self {
+            DataColumnSidecar::Fulu(column) => column.block_proposer_index(),
+            DataColumnSidecar::Gloas(_) => 0,
+        }
+    }
+
+    pub fn verify_inclusion_proof(&self) -> bool {
+        match self {
+            DataColumnSidecar::Fulu(column) => column.verify_inclusion_proof(),
+            // Gloas variant does not have inclusion proofs
+            DataColumnSidecar::Gloas(_) => true,
+        }
+    }
+
+    /// Custom SSZ decoder that takes a `ForkName` as context.
+    pub fn from_ssz_bytes_for_fork(
+        bytes: &[u8],
+        fork_name: ForkName,
+    ) -> Result<Self, ssz::DecodeError> {
+        match fork_name {
+            ForkName::Base
+            | ForkName::Altair
+            | ForkName::Bellatrix
+            | ForkName::Capella
+            | ForkName::Deneb
+            | ForkName::Electra => Err(ssz::DecodeError::NoMatchingVariant),
+            ForkName::Fulu => Ok(DataColumnSidecar::Fulu(
+                DataColumnSidecarFulu::from_ssz_bytes(bytes)?,
+            )),
+            ForkName::Gloas => Ok(DataColumnSidecar::Gloas(
+                DataColumnSidecarGloas::from_ssz_bytes(bytes)?,
+            )),
+        }
+    }
+
+    /// Try decoding each variant in sequence (slow, use when fork is unknown).
+    pub fn any_from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
+        DataColumnSidecarGloas::from_ssz_bytes(bytes)
+            .map(DataColumnSidecar::Gloas)
+            .or_else(|_| {
+                DataColumnSidecarFulu::from_ssz_bytes(bytes).map(DataColumnSidecar::Fulu)
+            })
+    }
+}
+
+impl<E: EthSpec> DataColumnSidecarFulu<E> {
+    pub fn slot(&self) -> Slot {
+        self.signed_block_header.message.slot
     }
 
     pub fn block_root(&self) -> Hash256 {
@@ -94,7 +196,6 @@ impl<E: EthSpec> DataColumnSidecar<E> {
     }
 
     pub fn min_size() -> usize {
-        // min size is one cell
         Self {
             index: 0,
             column: VariableList::new(vec![Cell::<E>::default()]).unwrap(),
@@ -131,6 +232,32 @@ impl<E: EthSpec> DataColumnSidecar<E> {
     }
 }
 
+impl<E: EthSpec> DataColumnSidecarGloas<E> {
+    pub fn min_size() -> usize {
+        Self {
+            index: 0,
+            column: VariableList::new(vec![Cell::<E>::default()]).unwrap(),
+            kzg_proofs: VariableList::new(vec![KzgProof::empty()]).unwrap(),
+            slot: Slot::new(0),
+            beacon_block_root: Hash256::ZERO,
+        }
+        .as_ssz_bytes()
+        .len()
+    }
+
+    pub fn max_size(max_blobs_per_block: usize) -> usize {
+        Self {
+            index: 0,
+            column: VariableList::new(vec![Cell::<E>::default(); max_blobs_per_block]).unwrap(),
+            kzg_proofs: VariableList::new(vec![KzgProof::empty(); max_blobs_per_block]).unwrap(),
+            slot: Slot::new(0),
+            beacon_block_root: Hash256::ZERO,
+        }
+        .as_ssz_bytes()
+        .len()
+    }
+}
+
 #[derive(Debug)]
 pub enum DataColumnSidecarError {
     ArithError(ArithError),
@@ -144,6 +271,7 @@ pub enum DataColumnSidecarError {
     SszError(SszError),
     BuildSidecarFailed(String),
     InvalidCellProofLength { expected: usize, actual: usize },
+    IncorrectVariant,
 }
 
 impl From<ArithError> for DataColumnSidecarError {

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -163,7 +163,9 @@ pub use crate::config_and_preset::{
 pub use crate::consolidation_request::ConsolidationRequest;
 pub use crate::contribution_and_proof::ContributionAndProof;
 pub use crate::data_column_sidecar::{
-    ColumnIndex, DataColumnSidecar, DataColumnSidecarList, DataColumnsByRootIdentifier,
+    ColumnIndex, DataColumnSidecar, DataColumnSidecarError, DataColumnSidecarFulu,
+    DataColumnSidecarGloas, DataColumnSidecarList, DataColumnSidecarRef,
+    DataColumnsByRootIdentifier,
 };
 pub use crate::data_column_subnet_id::DataColumnSubnetId;
 pub use crate::deposit::{DEPOSIT_TREE_DEPTH, Deposit};

--- a/plan.md
+++ b/plan.md
@@ -120,6 +120,32 @@ The next Ethereum hard fork is **Glamsterdam** (execution: Amsterdam, consensus:
 - **EIP-7916** - Data availability changes for gloas (DataColumnSidecar changes, removal of signed_block_header and kzg_commitments_inclusion_proof fields).
 - **EIP-8016** - Progressive data structures.
 
+### ⚠️⚠️⚠️ CRITICAL: BEFORE MERGING ANY TYPES/SSZ CHANGES ⚠️⚠️⚠️
+
+# YOU MUST RUN `make test-ef` TO VERIFY SPEC TESTS PASS
+
+# YOU MUST ADD TEST ENTRIES IN `testing/ef_tests/tests/tests.rs`
+
+For superstruct types like DataColumnSidecar (Fulu/Gloas variants), you need BOTH:
+1. **type_name entries** in `testing/ef_tests/src/type_name.rs` for each variant
+2. **test functions** in `testing/ef_tests/tests/tests.rs` - one per variant with the correct fork filter (e.g. `fulu_only()`, `gloas_and_later()`)
+
+Example pattern (see how BeaconBlockBody does it with separate Fulu/Gloas entries):
+```rust
+#[test]
+fn data_column_sidecar_fulu() {
+    SszStaticHandler::<DataColumnSidecarFulu<MinimalEthSpec>, MinimalEthSpec>::fulu_only().run();
+    SszStaticHandler::<DataColumnSidecarFulu<MainnetEthSpec>, MainnetEthSpec>::fulu_only().run();
+}
+#[test]
+fn data_column_sidecar_gloas() {
+    SszStaticHandler::<DataColumnSidecarGloas<MinimalEthSpec>, MinimalEthSpec>::gloas_and_later().run();
+    SszStaticHandler::<DataColumnSidecarGloas<MainnetEthSpec>, MainnetEthSpec>::gloas_and_later().run();
+}
+```
+
+Without this, SSZ static tests silently skip your type — you'll think it passes when it doesn't run at all.
+
 ### Implementation steps (detailed)
 
 #### Step 1: Types & Constants

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use types::{
     Attestation, AttestationRef, AttesterSlashing, AttesterSlashingRef, BeaconBlock, BeaconState,
-    BlobSidecar, BlobsList, BlockImportSource, Checkpoint, DataColumnSidecarList,
+    BlobSidecar, BlobsList, BlockImportSource, Checkpoint, DataColumnSidecar, DataColumnSidecarList,
     DataColumnSubnetId, ExecutionBlockHash, Hash256, IndexedAttestation, KzgProof,
     ProposerPreparationData, SignedBeaconBlock, Slot, Uint256,
 };
@@ -252,7 +252,15 @@ impl<E: EthSpec> LoadCase for ForkChoiceTest<E> {
                             columns_vec
                                 .into_iter()
                                 .map(|column| {
-                                    ssz_decode_file(&path.join(format!("{column}.ssz_snappy")))
+                                    ssz_decode_file_with(
+                                        &path.join(format!("{column}.ssz_snappy")),
+                                        |bytes| {
+                                            DataColumnSidecar::from_ssz_bytes_for_fork(
+                                                bytes, fork_name,
+                                            )
+                                            .map(Arc::new)
+                                        },
+                                    )
                                 })
                                 .collect::<Result<Vec<_>, _>>()
                         })
@@ -521,7 +529,7 @@ impl<E: EthSpec> Tester<E> {
             let gossip_verified_data_columns = columns
                 .into_iter()
                 .map(|column| {
-                    let subnet_id = DataColumnSubnetId::from_column_index(column.index, &self.spec);
+                    let subnet_id = DataColumnSubnetId::from_column_index(*column.index(), &self.spec);
                     GossipVerifiedDataColumn::new(column.clone(), subnet_id, &self.harness.chain)
                         .unwrap_or_else(|_| {
                             data_column_success = false;

--- a/testing/ef_tests/src/type_name.rs
+++ b/testing/ef_tests/src/type_name.rs
@@ -61,6 +61,8 @@ type_name!(BlobIdentifier);
 type_name_generic!(DataColumnsByRootIdentifier, "DataColumnsByRootIdentifier");
 type_name_generic!(BlobSidecar);
 type_name_generic!(DataColumnSidecar);
+type_name_generic!(DataColumnSidecarFulu, "DataColumnSidecar");
+type_name_generic!(DataColumnSidecarGloas, "DataColumnSidecar");
 type_name!(Checkpoint);
 type_name!(ConsolidationRequest);
 type_name_generic!(ContributionAndProof);

--- a/testing/ef_tests/tests/tests.rs
+++ b/testing/ef_tests/tests/tests.rs
@@ -692,11 +692,16 @@ mod ssz_static {
         SszStaticHandler::<HistoricalSummary, MainnetEthSpec>::capella_and_later().run();
     }
 
+    // DataColumnSidecar has no internal indicator of which fork it is for, so we test it separately.
     #[test]
     fn data_column_sidecar() {
-        SszStaticHandler::<DataColumnSidecar<MinimalEthSpec>, MinimalEthSpec>::fulu_and_later()
+        SszStaticHandler::<DataColumnSidecarFulu<MinimalEthSpec>, MinimalEthSpec>::fulu_only()
             .run();
-        SszStaticHandler::<DataColumnSidecar<MainnetEthSpec>, MainnetEthSpec>::fulu_and_later()
+        SszStaticHandler::<DataColumnSidecarFulu<MainnetEthSpec>, MainnetEthSpec>::fulu_only()
+            .run();
+        SszStaticHandler::<DataColumnSidecarGloas<MinimalEthSpec>, MinimalEthSpec>::gloas_only()
+            .run();
+        SszStaticHandler::<DataColumnSidecarGloas<MainnetEthSpec>, MainnetEthSpec>::gloas_only()
             .run();
     }
 


### PR DESCRIPTION
## Summary
- Convert `DataColumnSidecar` from a plain struct to a superstruct enum with `Fulu` and `Gloas` variants
- Gloas variant is slimmed down: drops `kzg_commitments`, `signed_block_header`, and `kzg_commitments_inclusion_proof` fields; adds `slot` and `beacon_block_root` fields
- Fix all cascading compilation errors across ~25 files in `beacon_chain`, `network`, `lighthouse_network`, `store`, `eth2`, `http_api`, and `ef_tests` crates
- Add SSZ static test registrations for both `DataColumnSidecarFulu` and `DataColumnSidecarGloas`

## Key changes
- `.index` field access → `.index()` method (returns `&u64`) across all crates
- `.signed_block_header` → `.signed_block_header()` partial getter (Fulu-only field, returns `Result`)
- `DataColumnSidecar::from_ssz_bytes` → `from_ssz_bytes_for_fork(bytes, fork)` or `any_from_ssz_bytes(bytes)`
- `min_size()`/`max_size()` moved to `DataColumnSidecarFulu` (used for RPC limits)
- Struct construction patterns → `DataColumnSidecar::Fulu(DataColumnSidecarFulu { .. })`
- Dispatch methods added: `slot()`, `block_root()`, `block_parent_root()`, `block_proposer_index()`, `verify_inclusion_proof()`

## Test plan
- [x] `cargo check` passes (full workspace)
- [x] `data_column_sidecar` SSZ static test passes (Fulu + Gloas variants, both minimal and mainnet)
- [x] `data_column_by_root_identifier` SSZ static test passes