### PR TITLE
feat: add proposer_preferences gossip topic (gloas ePBS)

### DIFF
--- a/beacon_node/beacon_processor/src/lib.rs
+++ b/beacon_node/beacon_processor/src/lib.rs
@@ -601,6 +601,7 @@ pub enum Work<E: EthSpec> {
     GossipExecutionBid(BlockingFn),
     GossipExecutionPayload(BlockingFn),
     GossipPayloadAttestation(BlockingFn),
+    GossipProposerPreferences(BlockingFn),
     RpcBlock {
         process_fn: AsyncFn,
     },
@@ -662,6 +663,7 @@ pub enum WorkType {
     GossipExecutionBid,
     GossipExecutionPayload,
     GossipPayloadAttestation,
+    GossipProposerPreferences,
     RpcBlock,
     RpcBlobs,
     RpcCustodyColumn,
@@ -714,6 +716,7 @@ impl<E: EthSpec> Work<E> {
             Work::GossipExecutionBid(_) => WorkType::GossipExecutionBid,
             Work::GossipExecutionPayload(_) => WorkType::GossipExecutionPayload,
             Work::GossipPayloadAttestation(_) => WorkType::GossipPayloadAttestation,
+            Work::GossipProposerPreferences(_) => WorkType::GossipProposerPreferences,
             Work::GossipBlsToExecutionChange(_) => WorkType::GossipBlsToExecutionChange,
             Work::RpcBlock { .. } => WorkType::RpcBlock,
             Work::RpcBlobs { .. } => WorkType::RpcBlobs,
@@ -1374,6 +1377,9 @@ impl<E: EthSpec> BeaconProcessor<E> {
                             Work::GossipPayloadAttestation { .. } => {
                                 gossip_payload_attestation_queue.push(work, work_id)
                             }
+                            Work::GossipProposerPreferences { .. } => {
+                                gossip_execution_bid_queue.push(work, work_id)
+                            }
                             Work::GossipSyncSignature { .. } => sync_message_queue.push(work),
                             Work::GossipSyncContribution { .. } => {
                                 sync_contribution_queue.push(work)
@@ -1665,6 +1671,7 @@ impl<E: EthSpec> BeaconProcessor<E> {
             | Work::GossipExecutionBid(process_fn)
             | Work::GossipExecutionPayload(process_fn)
             | Work::GossipPayloadAttestation(process_fn)
+            | Work::GossipProposerPreferences(process_fn)
             | Work::Status(process_fn)
             | Work::GossipBlsToExecutionChange(process_fn)
             | Work::LightClientBootstrapRequest(process_fn)

--- a/beacon_node/lighthouse_network/src/types/topics.rs
+++ b/beacon_node/lighthouse_network/src/types/topics.rs
@@ -27,6 +27,7 @@ pub const LIGHT_CLIENT_OPTIMISTIC_UPDATE: &str = "light_client_optimistic_update
 pub const EXECUTION_BID_TOPIC: &str = "execution_bid";
 pub const EXECUTION_PAYLOAD_TOPIC: &str = "execution_payload";
 pub const PAYLOAD_ATTESTATION_TOPIC: &str = "payload_attestation";
+pub const PROPOSER_PREFERENCES_TOPIC: &str = "proposer_preferences";
 
 #[derive(Debug)]
 pub struct TopicConfig {
@@ -99,6 +100,7 @@ pub fn core_topics_to_subscribe<E: EthSpec>(
         topics.push(GossipKind::ExecutionBid);
         topics.push(GossipKind::ExecutionPayload);
         topics.push(GossipKind::PayloadAttestation);
+        topics.push(GossipKind::ProposerPreferences);
     }
 
     topics
@@ -128,7 +130,8 @@ pub fn is_fork_non_core_topic(topic: &GossipTopic, _fork_name: ForkName) -> bool
         | GossipKind::LightClientOptimisticUpdate
         | GossipKind::ExecutionBid
         | GossipKind::ExecutionPayload
-        | GossipKind::PayloadAttestation => false,
+        | GossipKind::PayloadAttestation
+        | GossipKind::ProposerPreferences => false,
     }
 }
 
@@ -195,6 +198,8 @@ pub enum GossipKind {
     ExecutionPayload,
     /// Gloas ePBS: Topic for PTC members to publish payload attestations.
     PayloadAttestation,
+    /// Gloas ePBS: Topic for proposers to publish fee_recipient/gas_limit preferences.
+    ProposerPreferences,
 }
 
 impl std::fmt::Display for GossipKind {
@@ -280,6 +285,7 @@ impl GossipTopic {
                 EXECUTION_BID_TOPIC => GossipKind::ExecutionBid,
                 EXECUTION_PAYLOAD_TOPIC => GossipKind::ExecutionPayload,
                 PAYLOAD_ATTESTATION_TOPIC => GossipKind::PayloadAttestation,
+                PROPOSER_PREFERENCES_TOPIC => GossipKind::ProposerPreferences,
                 topic => match subnet_topic_index(topic) {
                     Some(kind) => kind,
                     None => return Err(format!("Unknown topic: {}", topic)),
@@ -348,6 +354,7 @@ impl std::fmt::Display for GossipTopic {
             GossipKind::ExecutionBid => EXECUTION_BID_TOPIC.into(),
             GossipKind::ExecutionPayload => EXECUTION_PAYLOAD_TOPIC.into(),
             GossipKind::PayloadAttestation => PAYLOAD_ATTESTATION_TOPIC.into(),
+            GossipKind::ProposerPreferences => PROPOSER_PREFERENCES_TOPIC.into(),
         };
         write!(
             f,

--- a/beacon_node/network/src/network_beacon_processor/mod.rs
+++ b/beacon_node/network/src/network_beacon_processor/mod.rs
@@ -354,6 +354,24 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         })
     }
 
+    /// Create a new `Work` event for a gloas proposer preferences message (ePBS).
+    pub fn send_gossip_proposer_preferences(
+        self: &Arc<Self>,
+        message_id: MessageId,
+        peer_id: PeerId,
+        preferences: Box<types::SignedProposerPreferences>,
+    ) -> Result<(), Error<T::EthSpec>> {
+        let processor = self.clone();
+        let process_fn = move || {
+            processor.process_gossip_proposer_preferences(message_id, peer_id, *preferences)
+        };
+
+        self.try_send(BeaconWorkEvent {
+            drop_during_sync: true,
+            work: Work::GossipProposerPreferences(Box::new(process_fn)),
+        })
+    }
+
     /// Create a new `Work` event for some exit.
     pub fn send_gossip_voluntary_exit(
         self: &Arc<Self>,

--- a/beacon_node/network/src/router.rs
+++ b/beacon_node/network/src/router.rs
@@ -498,6 +498,10 @@ impl<T: BeaconChainTypes> Router<T> {
                 self.network_beacon_processor
                     .send_gossip_payload_attestation(message_id, peer_id, attestation),
             ),
+            PubsubMessage::ProposerPreferences(preferences) => self.handle_beacon_processor_send_result(
+                self.network_beacon_processor
+                    .send_gossip_proposer_preferences(message_id, peer_id, preferences),
+            ),
         }
     }
 

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -66,7 +66,9 @@ pub mod pending_consolidation;
 pub mod pending_deposit;
 pub mod pending_partial_withdrawal;
 pub mod proposer_preparation_data;
+pub mod proposer_preferences;
 pub mod proposer_slashing;
+pub mod signed_proposer_preferences;
 pub mod relative_epoch;
 pub mod selection_proof;
 pub mod shuffling_id;
@@ -245,7 +247,9 @@ pub use crate::preset::{
     FuluPreset, GloasPreset,
 };
 pub use crate::proposer_preparation_data::ProposerPreparationData;
+pub use crate::proposer_preferences::ProposerPreferences;
 pub use crate::proposer_slashing::ProposerSlashing;
+pub use crate::signed_proposer_preferences::SignedProposerPreferences;
 pub use crate::relative_epoch::{Error as RelativeEpochError, RelativeEpoch};
 pub use crate::runtime_fixed_vector::RuntimeFixedVector;
 pub use crate::runtime_var_list::RuntimeVariableList;

--- a/consensus/types/src/proposer_preferences.rs
+++ b/consensus/types/src/proposer_preferences.rs
@@ -1,0 +1,41 @@
+use crate::test_utils::TestRandom;
+use crate::{Address, Slot, SignedRoot};
+use serde::{Deserialize, Serialize};
+use ssz_derive::{Decode, Encode};
+use test_random_derive::TestRandom;
+use tree_hash_derive::TreeHash;
+
+/// Proposer preferences for a specific slot in Gloas ePBS.
+///
+/// Validators publish their preferred `fee_recipient` and `gas_limit` for
+/// upcoming proposal slots. Builders use these to construct valid bids that
+/// match the proposer's requirements.
+///
+/// Reference: https://github.com/ethereum/consensus-specs/blob/dev/specs/gloas/p2p-interface.md#new-proposerpreferences
+#[derive(
+    Default, Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Encode, Decode, TreeHash,
+    TestRandom,
+)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct ProposerPreferences {
+    /// The slot this proposer is assigned to propose
+    pub proposal_slot: Slot,
+    /// Index of the validator publishing preferences
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub validator_index: u64,
+    /// Preferred fee recipient address for execution payload
+    #[serde(with = "serde_utils::address_hex")]
+    pub fee_recipient: Address,
+    /// Preferred gas limit for execution payload
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub gas_limit: u64,
+}
+
+impl SignedRoot for ProposerPreferences {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    ssz_and_tree_hash_tests!(ProposerPreferences);
+}

--- a/consensus/types/src/signed_proposer_preferences.rs
+++ b/consensus/types/src/signed_proposer_preferences.rs
@@ -1,0 +1,47 @@
+use crate::test_utils::TestRandom;
+use crate::{ForkName, ProposerPreferences};
+use bls::Signature;
+use context_deserialize::context_deserialize;
+use serde::{Deserialize, Serialize};
+use ssz_derive::{Decode, Encode};
+use test_random_derive::TestRandom;
+use tree_hash_derive::TreeHash;
+
+/// Signed proposer preferences for Gloas ePBS.
+///
+/// Validators sign their preferences to prove authenticity. The signature is
+/// verified against the validator's public key before forwarding on gossip.
+///
+/// Reference: https://github.com/ethereum/consensus-specs/blob/dev/specs/gloas/p2p-interface.md#new-signedproposerpreferences
+#[derive(
+    Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[context_deserialize(ForkName)]
+pub struct SignedProposerPreferences {
+    pub message: ProposerPreferences,
+    pub signature: Signature,
+}
+
+impl SignedProposerPreferences {
+    /// Create an empty signed proposer preferences (useful for defaults and testing)
+    pub fn empty() -> Self {
+        Self {
+            message: ProposerPreferences::default(),
+            signature: Signature::empty(),
+        }
+    }
+}
+
+impl Default for SignedProposerPreferences {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    ssz_and_tree_hash_tests!(SignedProposerPreferences);
+}


### PR DESCRIPTION
## Motivation

The Gloas spec defines a new `proposer_preferences` gossip topic ([p2p-interface.md](https://github.com/ethereum/consensus-specs/blob/dev/specs/gloas/p2p-interface.md#proposer_preferences)) that allows validators to publish their preferred `fee_recipient` and `gas_limit` for upcoming proposal slots. Builders use these to construct valid bids matching the proposer's requirements.

This topic was completely missing from vibehouse.

## Changes

### New types (`consensus/types/`)
- `ProposerPreferences` — container: `proposal_slot`, `validator_index`, `fee_recipient`, `gas_limit`
- `SignedProposerPreferences` — signed wrapper with BLS signature

### Gossip infrastructure
- Add `ProposerPreferences` variant to `GossipKind` enum + topic constant
- Subscribe to topic when Gloas fork is active
- Add SSZ encode/decode in `PubsubMessage`
- Route through beacon processor work queue

### Gossip validation (partial)
Implements the following spec checks:
- `[IGNORE]` `proposal_slot` is in the next epoch
- `[REJECT]` `validator_index` is valid proposer for that slot (via `proposer_lookahead`)

### TODOs (follow-up)
- `[IGNORE]` dedup: first valid message per validator+slot (needs `ObservedProposerPreferences`)
- `[REJECT]` signature verification (needs `domain_proposer_preferences` wired into signing domain helpers)
- Storage/cache for builders to reference preferences when constructing bids

## Meme

![proposer preferences](https://raw.githubusercontent.com/lodekeeper/vibehouse/memes/.github/memes/pr23-proposer-preferences.png)

---
*AI-assisted: This PR was authored with AI assistance from Lodekeeper.*