### PR TITLE
fix gloas consensus bugs: unsafe arithmetic, stale TODO, constant duplication

### DIFF
--- a/beacon_node/beacon_chain/src/gloas_verification.rs
+++ b/beacon_node/beacon_chain/src/gloas_verification.rs
@@ -193,7 +193,6 @@ impl From<BeaconStateError> for PayloadAttestationError {
 #[derive(Debug, Clone)]
 pub struct VerifiedExecutionBid<T: BeaconChainTypes> {
     bid: SignedExecutionPayloadBid<T::EthSpec>,
-    // TODO: Add builder_pubkey field when we implement full signature verification
 }
 
 impl<T: BeaconChainTypes> VerifiedExecutionBid<T> {
@@ -361,7 +360,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             });
         }
 
-        // Check 1b: Spec: [REJECT] bid.execution_payment is zero.
+        // Check 1b: Spec: [REJECT] bid.execution_payment must be zero.
+        // Reject bids with non-zero execution_payment.
         if bid.message.execution_payment != 0 {
             return Err(ExecutionBidError::NonZeroExecutionPayment {
                 execution_payment: bid.message.execution_payment,

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -917,10 +917,7 @@ impl ProtoArray {
         // Gloas ePBS: For external builder blocks, payload must be revealed to be viable for head.
         // Self-build blocks (builder_index = None or BUILDER_INDEX_SELF_BUILD) are always viable.
         if let Some(builder_index) = node.builder_index {
-            // BUILDER_INDEX_SELF_BUILD is u64::MAX - proposer built their own payload
-            const BUILDER_INDEX_SELF_BUILD: u64 = u64::MAX;
-            
-            if builder_index != BUILDER_INDEX_SELF_BUILD && !node.payload_revealed {
+            if builder_index != types::consts::gloas::BUILDER_INDEX_SELF_BUILD && !node.payload_revealed {
                 // External builder block without revealed payload - not viable for head
                 return false;
             }

--- a/consensus/state_processing/src/per_block_processing/gloas.rs
+++ b/consensus/state_processing/src/per_block_processing/gloas.rs
@@ -593,7 +593,9 @@ pub fn process_withdrawals_gloas<E: EthSpec>(
                     }
                 }
 
-                builder_index = (builder_index + 1) % builders_count as u64;
+                builder_index = builder_index
+                    .safe_add(1)?
+                    .safe_rem(builders_count as u64)?;
                 processed_builders_sweep_count += 1;
             }
         }


### PR DESCRIPTION
## Summary

Fixes four issues found during code review of the gloas ePBS implementation:

- **Unsafe arithmetic in consensus code** (`consensus/state_processing/src/per_block_processing/gloas.rs:596`): The builder sweep loop used plain `+` and `%` operators (`builder_index = (builder_index + 1) % builders_count`). Per the project's CLAUDE.md rules, all arithmetic in `consensus/` (excluding `types/`) must use saturating or checked arithmetic. Replaced with `safe_add(1)?.safe_rem(builders_count)?`.

- **Stale TODO comment** (`beacon_node/beacon_chain/src/gloas_verification.rs:196`): The TODO said "Add builder_pubkey field when we implement full signature verification" but signature verification is already fully implemented in `verify_execution_bid_for_gossip()` at lines 432-450. Removed the misleading comment.

- **Duplicated constant** (`consensus/proto_array/src/proto_array.rs:921`): `BUILDER_INDEX_SELF_BUILD` was redefined locally as `const BUILDER_INDEX_SELF_BUILD: u64 = u64::MAX` instead of using the canonical `types::consts::gloas::BUILDER_INDEX_SELF_BUILD`. If the canonical value ever changed, this local copy would silently diverge.

- **Misleading spec comment** (`beacon_node/beacon_chain/src/gloas_verification.rs:363`): The comment `[REJECT] bid.execution_payment is zero` reads ambiguously — it could be interpreted as "reject if it IS zero" when the actual spec meaning is "the condition that must hold is that execution_payment is zero." Clarified to `[REJECT] bid.execution_payment must be zero` with an explicit note.

## Test plan

- [ ] Verify `cargo check -p state_processing` passes (safe_add/safe_rem change)
- [ ] Verify `cargo check -p proto_array` passes (constant import change)
- [ ] Verify `make test-ef` still passes 77/77 tests
- [ ] Verify no regressions in `cargo check -p beacon_chain`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
