### PR TITLE
chore: bump rust to 1.91.0-trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.88.0-bullseye AS builder
+FROM rust:1.91.0-trixie AS builder
 RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake libclang-dev
 COPY . vibehouse
 ARG FEATURES

--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -1,9 +1,9 @@
-# Define the Rust image as an argument with a default to x86_64 Rust 1.88 image based on Debian Bullseye
-ARG RUST_IMAGE="rust:1.88-bullseye@sha256:8e3c421122bf4cd3b2a866af41a4dd52d87ad9e315fd2cb5100e87a7187a9816"
+# Define the Rust image as an argument with a default to x86_64 Rust 1.91 image based on Debian Trixie
+ARG RUST_IMAGE="rust:1.91-trixie@sha256:a0dba1c1b2c90585fc44421b55ddf8063323760dc644ba1d35f5b389ad3e8e14"
 FROM ${RUST_IMAGE} AS builder
 
 # Install specific version of the build dependencies
-RUN apt-get update && apt-get install -y libclang-dev=1:11.0-51+nmu5 cmake=3.18.4-2+deb11u1
+RUN apt-get update && apt-get install -y libclang-dev=1:19.0-63 cmake=3.31.6-2
 
 # Add target architecture argument with default value
 ARG RUST_TARGET="x86_64-unknown-linux-gnu"

--- a/lcli/Dockerfile
+++ b/lcli/Dockerfile
@@ -1,7 +1,7 @@
 # `lcli` requires the full project to be in scope, so this should be built either:
 #  - from the vibehouse dir with the command: `docker build -f ./lcli/Dockerfile .`
 #  - from the current directory with the command: `docker build -f ./Dockerfile ../`
-FROM rust:1.88.0-bullseye AS builder
+FROM rust:1.91.0-trixie AS builder
 RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake libclang-dev
 COPY . vibehouse
 ARG FEATURES

--- a/vibehouse/Cargo.toml
+++ b/vibehouse/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = []
 edition = { workspace = true }
 autotests = false
-rust-version = "1.88.0"
+rust-version = "1.91.0"
 
 # Prevent cargo-udeps from flagging the dummy package `target_check`, which exists only
 # to assert properties of the compilation target.


### PR DESCRIPTION
## Summary
- Bump Rust from 1.88.0-bullseye to 1.91.0-trixie (Debian 13) across all Dockerfiles
- Update MSRV in `vibehouse/Cargo.toml` from 1.88.0 to 1.91.0
- Update pinned `libclang-dev` and `cmake` versions in `Dockerfile.reproducible` for Trixie

Build was failing because `alloy-consensus`, `alloy-eips`, and `alloy-tx-macros` 1.7.3 require rustc 1.91+, and `redb` 3.1.1 requires rustc 1.89+.

## Test plan
- [x] Docker build completes successfully with `rust:1.91.0-trixie`
- [x] `cargo check` passes (verified locally on rustc 1.93.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)